### PR TITLE
Fix obs issue of background color

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ Open Captions Overlay는 자막을 방송 송출 프로그램(OBS, XSplit 등)�
 
 여기서 `#95BBDF` 값을 변경할 강조 색상 코드로 변경해주세요.
 
+### 3. 오버레이의 바탕이 투명하지 않은 경우
+방송 송출 프로그램에서 Open Captions Overlay 브라우저 소스의 CSS에 다음 내용을 추가합니다.
+
+```css
+body {
+    background: transparent;
+}
+```
+
 ## Development
 
 이하의 내용은 일반 사용자가 아닌 개발자를 위한 내용입니다.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ Open Captions Overlay는 자막을 방송 송출 프로그램(OBS, XSplit 등)�
 
 ```css
 body {
-    background: transparent;
+    background-color: rgba(0, 0, 0, 0);
+    margin: 0px auto;
+    overflow: hidden;
 }
 ```
 

--- a/frontend/overlay-sans.html
+++ b/frontend/overlay-sans.html
@@ -9,7 +9,6 @@
 
         body {
             overflow: hidden;
-            background: #000;
         }
 
         .root-container {


### PR DESCRIPTION
Currently on Sans mode, it looks like this. (OBS 24.0.1 linux with browser source plugin installed)
![image](https://user-images.githubusercontent.com/29011440/66150060-5e469680-e64f-11e9-98a4-8fd3b580730f.png)

Updating this would make this transparent, so only show up OC overlay when talking.